### PR TITLE
Fix CSS selectors for insecure password notices

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,4 +1,4 @@
-.sp-insecure-password-notice td {
+.nfd-sp-insecure-password-notice td {
 	padding: 0 10px;
 }
 

--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -16,7 +16,7 @@
 	display: none !important;
 }
 
-.message.sp-insecure-password-notice {
+.message.nfd-sp-insecure-password-notice {
 	border-left-color: #d63638;
 }
 

--- a/assets/js/secure-passwords.js
+++ b/assets/js/secure-passwords.js
@@ -49,11 +49,11 @@ function insecurePasswordNotice() {
 
 	if ( document.body.classList.contains( 'login-action-rp' ) ) {
 		insecureNotice = document.createElement( 'p' );
-		insecureNotice.className = 'message sp-insecure-password-notice';
+		insecureNotice.className = 'message nfd-sp-insecure-password-notice';
 		insecureNotice.innerHTML = messageText;
 	} else {
 		insecureNotice = document.createElement( 'tr' );
-		insecureNotice.className = 'form-field sp-insecure-password-notice';
+		insecureNotice.className = 'form-field nfd-sp-insecure-password-notice';
 
 		insecureNotice.appendChild( document.createElement( 'th' ) );
 		insecureNotice.appendChild( document.createElement( 'td' ) );
@@ -74,7 +74,7 @@ function insecurePasswordNotice() {
 function insecurePasswordDetected() {
 	hideWeakPasswordOverride();
 
-	if ( 0 < document.getElementsByClassName('sp-insecure-password-notice').length ) {
+	if ( 0 < document.getElementsByClassName('nfd-sp-insecure-password-notice').length ) {
 		return;
 	}
 
@@ -95,7 +95,7 @@ function insecurePasswordDetected() {
  * Takes appropriate actions when a secure password is entered.
  */
 function securePasswordDetected() {
-	const notices = document.getElementsByClassName( 'sp-insecure-password-notice' );
+	const notices = document.getElementsByClassName( 'nfd-sp-insecure-password-notice' );
 
 	if ( notices.length > 0 ) {
 		Array.prototype.forEach.call( notices, function( element ) {


### PR DESCRIPTION
## Proposed changes

This corrects a typo in the login screen CSS file to style the module's warning as red, and also renames the class everywhere to have an `nfd-` prefix to better match the rest of the module's code.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
