### PR TITLE
Protect against a TypeError when the `#pass1` field is not present.

### DIFF
--- a/assets/js/secure-passwords.js
+++ b/assets/js/secure-passwords.js
@@ -121,23 +121,24 @@ function hideWeakPasswordOverride() {
 	document.getElementsByClassName( 'pw-weak' )[0].style.display = "none";
 }
 
-if ( window ) {
-	window.addEventListener('load', function () {
-		const passwordField = document.getElementById('pass1');
+window.addEventListener('load', function () {
+	const passwordField = document.getElementById('pass1');
+
+	if (passwordField) {
 		passwordField.addEventListener('keyup', debounce(passwordKeyup));
+	}
 
-		const generatePasswordButtons = document.getElementsByClassName('wp-generate-pw');
+	const generatePasswordButtons = document.getElementsByClassName('wp-generate-pw');
 
-		if (generatePasswordButtons.length > 0) {
-			Array.prototype.forEach.call(generatePasswordButtons, function (element) {
-				/*
-				 * When generate password buttons are clicked, it's safe to assume that the returned
-				 * password is secure.
-				 */
-				element.addEventListener('click', function () {
-					securePasswordDetected();
-				});
+	if (generatePasswordButtons.length > 0) {
+		Array.prototype.forEach.call(generatePasswordButtons, function (element) {
+			/*
+			 * When generate password buttons are clicked, it's safe to assume that the returned
+			 * password is secure.
+			 */
+			element.addEventListener('click', function () {
+				securePasswordDetected();
 			});
-		}
-	});
-}
+		});
+	}
+});


### PR DESCRIPTION
## Proposed changes

Fixes the failures in Cypress: https://github.com/bluehost/bluehost-wordpress-plugin/runs/5995837665?check_suite_focus=true.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
